### PR TITLE
warn when encountering a mojito rollup

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -145,6 +145,11 @@ ShakerCore.prototype._includeResources = function (includes, resources, absolute
         files = includes.filter(function (i) {return libpath.extname(i) !== ""; }),
         //take all resources that are contained in the given folders
         filtered = resources.filter(function (item) {
+            // Shaker and mojito rollups are not compatible, warn the user if needed
+            if (item.indexOf('/rollup.') !== -1) {
+                logger.error('incompatible mojito rollup found: ' + item);
+            }
+
             for (j = 0; j < folders.length; j++) {
                 if (item.indexOf(folders[j]) !== -1) {
                     return true;


### PR DESCRIPTION
mojito rollups and shaker are incompatible, sometimes the presence of rollups causes shaker to miss assets. report this error to the user.
