### PR TITLE
TunnelProxy override for upcoming DaliProxy removal

### DIFF
--- a/mojits/TunnelProxy/autoload/store-provider.server.js
+++ b/mojits/TunnelProxy/autoload/store-provider.server.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+
+/*jslint anon:true, sloppy:true*/
+/*global YUI*/
+
+
+YUI.add('tunnel-store-provider-addon', function(Y, NAME) {
+
+    function Addon(command, adapter, ac) {
+        this.instance = command.instance;
+        this.scripts = {};
+        this.ac = ac;
+        this.dispatch = ac.dispatch;
+    }
+
+
+    Addon.prototype = {
+
+        namespace: 'store',
+
+        /**
+         * Declaration of store requirement.
+         * @private
+         * @param {ResourceStore} rs The resource store.
+         */
+        setStore: function(rs) {
+            this.rs = rs;
+            if (rs) {
+                Y.log('Initialized and activated with Resource Store', 'info',
+                    NAME);
+            }
+        },
+
+
+        getStore: function() {
+            return this.rs;
+        }
+    };
+
+    Y.namespace('mojito.addons.ac').store = Addon;
+
+}, '0.1.0');

--- a/mojits/TunnelProxy/controller.server.js
+++ b/mojits/TunnelProxy/controller.server.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+
+/*jslint anon:true, sloppy:true nomen:true*/
+/*global YUI*/
+
+YUI.add('TunnelProxy', function(Y, NAME) {
+
+
+    function makeAdapter(ac) {
+        var oldAdapter = ac._adapter,
+            newAdapter;
+
+        newAdapter = Y.mix(oldAdapter, {
+
+            rpc: {
+                originalDone: oldAdapter.done,
+                ac: ac,
+                buffer: {
+                    data: '',
+                    meta: {}
+                }
+            },
+
+            _updateBuffer: function(data, meta) {
+                var buff = this.rpc.buffer;
+                buff.data = buff.data + data;
+                buff.meta = Y.mojito.util.metaMerge(buff.meta, meta);
+                // metaMerge will strip off the view info, but we need that for
+                // RPC calls, so we put it back
+                if (meta.view) {
+                    if (buff.meta.view) {
+                        buff.meta.view = Y.mojito.util.metaMerge(
+                            buff.meta.view,
+                            meta.view
+                        );
+                    } else {
+                        buff.meta.view = meta.view;
+                    }
+                }
+            },
+
+            flush: function(data, meta) {
+                this._updateBuffer(data, meta);
+            },
+
+            done: function(data, meta) {
+                var out,
+                    buffer = this.rpc.buffer;
+                this._updateBuffer(data, meta);
+                out = {
+                    status: meta.http.code,
+                    data: {
+                        html: buffer.data,
+                        // including the meta data for resolution on the
+                        // client
+                        meta: buffer.meta
+                    }
+                };
+                // We need to do this so that the original done method will
+                // (eventually) be called.  If we don't, we'll loop back to
+                // this method, recursing forever.
+                this.shakeMeta(out.data.meta);
+                this.done = this.rpc.originalDone;
+                this.rpc.ac.done(out, 'json');
+            },
+            shakeMeta: function (meta) {
+                //second param means we are in tunnel.
+                ac.shaker.run(meta, true);
+            }
+
+        }, true);
+
+        return newAdapter;
+    }
+
+
+    Y.namespace('mojito.controllers')[NAME] = {
+
+        init: function(config) {
+            this.config = config;
+        },
+
+        index: function(ac) {
+            // This key is set by the TunnelServer in _handleRpc().
+            var proxyCommand = ac.params.body('proxyCommand'),
+                txId = ac.params.body('txId');
+
+            if (!proxyCommand) {
+                ac.error(
+                    'Cannot execute TunnelProxy mojit without a proxy command.'
+                );
+                return;
+            }
+
+            // dispatch the command as the proxy
+            ac._dispatch(proxyCommand, makeAdapter(ac));
+        }
+    };
+
+}, '0.1.0', {requires: [
+    'mojito-shaker-addon',
+    'mojito-http-addon',
+    'mojito-util'
+]});

--- a/mojits/TunnelProxy/defaults.json
+++ b/mojits/TunnelProxy/defaults.json
@@ -1,0 +1,7 @@
+[
+    {
+        "settings": [ "master" ],
+        "config": {
+        }
+    }
+]

--- a/mojits/TunnelProxy/definition.json
+++ b/mojits/TunnelProxy/definition.json
@@ -1,0 +1,5 @@
+[
+    {
+        "settings": [ "master" ]
+    }
+]


### PR DESCRIPTION
This ports the override of DaliProxy to the renamed TunnelProxy mojit: https://github.com/yahoo/mojito/pull/345

Evaluate whether this is needed with the new resource store or not. I was not able to get Shaker tests to run.
