### PR TITLE
Fixing the error:"Self is not defined at line:299"

### DIFF
--- a/lib/shaker.js
+++ b/lib/shaker.js
@@ -258,7 +258,8 @@ Shaker.prototype = {
         var queue = new gear.Queue({registry: this._registry}),
             writeTask = shakerOptions.task || Shaker.DEFAULT_TASK,
             taskOptions = shakerOptions.taskConfig,
-            resourceList = [];
+            resourceList = [],
+            self = this;
 
         queue.tasks({
             //js: it may need some preprocessing


### PR DESCRIPTION
Problem: I was getting the following error.

/home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/lib/shaker.js:299
                self.logger.error('[SHAKER] - Processing resources: ' +
                ^
ReferenceError: self is not defined
    at /home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/lib/shaker.js:299:17
    at /home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/node_modules/async/lib/async.js:428:21
    at /home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/node_modules/async/lib/async.js:190:13
    at /home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/node_modules/async/lib/async.js:88:21
    at /home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/node_modules/async/lib/async.js:187:17
    at Queue.<anonymous> (/home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/node_modules/gear-lib/lib/jsminify.js:23:9)
    at /home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/node_modules/async/lib/async.js:185:13
            //views: we need to precompile the views for sure
    at /home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/node_modules/async/lib/async.js:86:13
    at Array.forEach (native)
    at /home/skapoor/cricket/mojito4Upgrade/node_modules/mojito-shaker/node_modules/async/lib/async.js:26:24

Solution: As self  variable was not defined in processMojitJS Function. I just defined it.

Please review and accept the change if you find its correct.

-Sumit
