### PR TITLE
enable `mojito start` for mojito@"<0.7.0" or mojito + mojito-cli

### DIFF
--- a/bin/mojito-shake
+++ b/bin/mojito-shake
@@ -91,11 +91,10 @@ function main() {
     }
 
     if (argInfo.errors && argInfo.errors.length > 0) {
-        utils = require('mojito/lib/management/utils')
         argInfo.errors.forEach(function(e) {
-            utils.log(e);
+            console.error(e);
         });
-        //utils.error('Invalid command line.', "Try 'mojito help <command>'.");
+        //console.error('Invalid command line.', "Try 'mojito help <command>'.");
         return;
     }
 

--- a/commands/shake.js
+++ b/commands/shake.js
@@ -4,9 +4,54 @@
  * See the accompanying LICENSE file for terms.
  */
 
-var utils = require('mojito/lib/management/utils'),
-    mojitoStart = require('mojito/lib/app/commands/start'),
+var resolve = require('path').resolve,
     ShakerCompiler = require('../lib/compiler').ShakerCompiler;
+
+
+// mojito@">=0.7.0" and mojito-cli installed globally or locally
+function mojitoCli(cb) {
+    var args = ['start'].concat(process.argv.slice(2)),
+        cwd = process.cwd(),
+        fn;
+
+    try {
+    	fn = require('mojito-cli');
+    } catch (err) {
+    	fn = require(resolve(cwd, 'node_modules/mojito-cli'));
+    }
+
+    fn(args, cwd, cb);
+}
+
+// mojito@"<0.7.0" start command
+function mojitoLib(params, options, cb) {
+    var fn = require('mojito/lib/app/commands/start');
+
+    fn.run(params, options, cb);
+}
+
+// try to invoke `mojito start` for mojito@"<0.7.0" or mojito + mojito-cli
+function mojitoStart(params, options, cb) {
+    try {
+        mojitoCli(cb);
+    } catch (err) {
+        console.log(err);
+        try {
+            mojitoLib(params, options, cb);
+        } catch (er2) {
+            console.error('`mojito start` could not be invoked.');
+            cb(er2.message);
+        }
+    }
+}
+
+function done(err, msg) {
+    if (err) {
+        console.error(err);
+    } else {
+        console.log(msg || 'Mojito started');
+    }
+}
 
 /**
  * Convert a CSV string into a context object.
@@ -25,7 +70,7 @@ function contextCsvToObject(s) {
         if (pair[0]) {
             pair[0] = pair[0].trim();
             if (!pair[1]) {
-                utils.warn('Missing value for context key: ' + pair[0]);
+                console.warn('Missing value for context key: ' + pair[0]);
             } else {
                 pair[1] = pair[1].trim();
                 ctx[pair[0]] = pair[1];
@@ -102,18 +147,12 @@ exports.run = function (params, options) {
         if (err) {
             // disable logger to prevent further messages after a failure
             compiler.logger.log = function () {};
-            utils.error('Shaker compilation failed: ' + err);
+            console.error('Shaker compilation failed: ' + err);
         } else {
-            utils.success('Shaker compilation done.');
+            console.log('Shaker compilation done.');
             if (options.run) {
                 delete options.run;
-                mojitoStart.run(params, options, function (err) {
-                    if (err) {
-                        utils.error(err);
-                    } else {
-                        utils.success('Mojito done.');
-                    }
-                });
+                mojitoStart(params, options, done);
             }
         }
     });


### PR DESCRIPTION
- change utils-based logging with plain console logging
- try to invoke `mojito start` one of these ways (in order)
  1. mojito-cli installed globally, locally with shaker, or somewhere in `module.paths`
  2. mojito-cli installed locally with the application (`$CWD/node_modules/mojito-cli`)
  3. mojito installed with mojito-shaker (as before)

The resolution of mojito-cli (1 & 2) can be simplified if mojito-shaker declares mojito-cli as a devDependency, which will require mojito@0.7.0 or greater. I hesitated to do that in this PR, but if/when that's ok I can do another PR.

Thanks.
